### PR TITLE
OSCKit crashes on iPhone 5 running iOS 8.1

### DIFF
--- a/OSCKit/OSCProtocol.mm
+++ b/OSCKit/OSCProtocol.mm
@@ -3,7 +3,7 @@
 
 #import "OSCProtocol.h"
 
-const static int BUFFER_SIZE = 1024 * 1024;
+const static int BUFFER_SIZE = 512 * 1024;
 
 @implementation OSCProtocol
 


### PR DESCRIPTION
Hi,

first off, thanks for this library! I'm currently trying it out in a Swift project targeting iOS: https://github.com/codeflows/LivePlaylist/blob/master/LivePlaylist/PlaylistViewController.swift#L21-L22

Sending OSC messages worked fine in the Xcode emulator, but when running the code on an actual device (iPhone 5 / iOS 8.1), it crashed with EXC_BAD_ACCESS:

![screenshot 2014-12-08 16 45 25](https://cloud.githubusercontent.com/assets/29481/5340987/f3dc3766-7efa-11e4-8a88-f6b969c54ff5.png)

Lowering the buffer size to 512kB (or anything under approx. 1000*1024 bytes) fixed the problem and the code now works on iOS as well.

I know next to nothing about C/C++, so maybe there's a better solution to this problem?
- Jari
