### PR TITLE
Osc bundle support

### DIFF
--- a/OSCKit/OSCProtocol.h
+++ b/OSCKit/OSCProtocol.h
@@ -4,7 +4,9 @@
 
 @interface OSCProtocol : NSObject
 
+typedef void (^OSCMessageCallback)(OSCMessage*);
+
 + (NSData*)packMessage:(OSCMessage*)message;
-+ (OSCMessage*)unpackMessage:(NSData*)data;
++ (void)unpackMessages:(NSData*)data withCallback:(OSCMessageCallback)callback;
 
 @end

--- a/OSCKit/OSCServer.m
+++ b/OSCKit/OSCServer.m
@@ -52,7 +52,10 @@
 
 - (void)udpSocket:(GCDAsyncUdpSocket *)sock didReceiveData:(NSData *)data fromAddress:(NSData *)address withFilterContext:(id)filterContext
 {
-  [self.delegate handleMessage:[OSCProtocol unpackMessage:data]];
+  [OSCProtocol unpackMessages:data withCallback:^(OSCMessage* message){
+    [self.delegate handleMessage:message];
+  }];
+;
 }
 
 @end

--- a/OSCKitTests/OSCKitTests.m
+++ b/OSCKitTests/OSCKitTests.m
@@ -35,7 +35,12 @@
 
 - (void)testPacket {
   OSCMessage* message1 = [OSCMessage to:@"/hello" with:@[@1, @524543432, @3.2f, @"hello"]];
-  OSCMessage* message2 = [OSCProtocol unpackMessage:[OSCProtocol packMessage:message1]];
+  NSData* packedMessage = [OSCProtocol packMessage:message1];
+  
+  __block OSCMessage* message2;
+  [OSCProtocol unpackMessages:packedMessage withCallback:^(OSCMessage* message){
+    message2 = message;
+  }];
   
   XCTAssert([message1.address isEqualToString:message2.address]);
   


### PR DESCRIPTION
Hi again, and happy holidays!

Today I noticed that some OSC replies weren't getting through to my OSCServerDelegate implementation. On a closer look, I noticed that these messages were bundled and bundles were being silently ignored. (FWIW, I'm interfacing against Ableton Live's LiveOSC which bundles messages in some cases.)

I took a stab at implementing the bundle support for incoming messages. The code is adapted from `OscPacketListener.h`.

I renamed `OSCProtocol.unpackMessage` to `OSCProtocol.unpackMessages`, as one arriving packet might contain many messages. Also, I made the method callback-based which seemed straightforward to implement (vs constructing & returning an intermediate message array array from `unpackMessages`.)

One big shortcoming for now is the lack of tests for unpacking bundled messages. I did fix the compilation errors I caused in the tests but couldn't actually run the tests in XCode for some reason.

What do you think?