### PR TITLE
Add arm64 support

### DIFF
--- a/OSCKit/oscpack/OscOutboundPacketStream.h
+++ b/OSCKit/oscpack/OscOutboundPacketStream.h
@@ -105,7 +105,7 @@ public:
     OutboundPacketStream& operator<<( const InfinitumType& rhs );
     OutboundPacketStream& operator<<( int32 rhs );
 
-#if !(defined(__x86_64__) || defined(_M_X64))
+#if !(defined(__x86_64__) || defined(_M_X64) || defined(__arm64__))
     OutboundPacketStream& operator<<( int rhs )
             { *this << (int32)rhs; return *this; }
 #endif

--- a/OSCKit/oscpack/OscReceivedElements.h
+++ b/OSCKit/oscpack/OscReceivedElements.h
@@ -100,7 +100,7 @@ public:
         : contents_( contents )
         , size_( ValidateSize( (osc_bundle_element_size_t)size ) ) {}
 
-#if !(defined(__x86_64__) || defined(_M_X64))
+#if !(defined(__x86_64__) || defined(_M_X64) || defined(__arm64__))
     ReceivedPacket( const char *contents, int size )
         : contents_( contents )
         , size_( ValidateSize( (osc_bundle_element_size_t)size ) ) {}

--- a/OSCKit/oscpack/OscTypes.h
+++ b/OSCKit/oscpack/OscTypes.h
@@ -47,7 +47,7 @@ namespace osc{
 typedef __int64 int64;
 typedef unsigned __int64 uint64;
 
-#elif defined(__x86_64__) || defined(_M_X64)
+#elif defined(__x86_64__) || defined(_M_X64) || defined(__arm64__)
 
 typedef long int64;
 typedef unsigned long uint64;
@@ -61,7 +61,7 @@ typedef unsigned long long uint64;
 
 
 
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__x86_64__) || defined(_M_X64) || defined(__arm64__)
 
 typedef signed int int32;
 typedef unsigned int uint32;


### PR DESCRIPTION
Hi again!

I recently got an iPhone 6 and noticed that OSCKit isn't working on 64-bit ARM processors. To fix this, I picked the necessary changes originally made in this iOS-oscpack commit: https://github.com/heisters/iOS-oscpack/commit/aae5d8e038603b0533a3458a27b35c2af4e66437

Let me know how this looks!